### PR TITLE
Add MIR payment system pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 target
 Cargo.lock
+
+# Jetbrains products
+./.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "card-validate"
-version = "2.2.3"
+version = "2.3.0"
 description = "Rust card validate detects and validates credit card numbers"
 readme = "README.md"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Detects and validates credit card numbers (type of card, number length and Luhn 
 **Credit cards:**
 
 * Visa
+* MIR
 * MasterCard
 * American Express
 * Diners Club
@@ -38,7 +39,7 @@ In your `Cargo.toml`:
 
 ```toml
 [dependencies]
-card-validate = "2.1"
+card-validate = "2.3"
 ```
 
 ## Validate a number

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ lazy_static! {
     static ref FORBRUGSFORENINGEN_PATTERN_REGEX: Regex = Regex::new(r"^600").unwrap();
     static ref DANKORT_PATTERN_REGEX: Regex = Regex::new(r"^5019").unwrap();
     static ref VISA_PATTERN_REGEX: Regex = Regex::new(r"^4").unwrap();
+    static ref MIR_PATTERN_REGEX: Regex = Regex::new(r"^220[0-4]").unwrap();
     static ref MASTERCARD_PATTERN_REGEX: Regex = Regex::new(r"^(5[1-5]|2[2-7])").unwrap();
     static ref AMEX_PATTERN_REGEX: Regex = Regex::new(r"^3[47]").unwrap();
     static ref DINERSCLUB_PATTERN_REGEX: Regex = Regex::new(r"^3[0689]").unwrap();
@@ -39,6 +40,7 @@ pub enum Type {
 
     // Credit
     Visa,
+    MIR,
     MasterCard,
     Amex,
     DinersClub,
@@ -70,6 +72,7 @@ impl Type {
             Type::Forbrugsforeningen => "forbrugsforeningen",
             Type::Dankort => "dankort",
             Type::Visa => "visa",
+            Type::MIR => "mir",
             Type::MasterCard => "mastercard",
             Type::Amex => "amex",
             Type::DinersClub => "dinersclub",
@@ -88,6 +91,7 @@ impl Type {
             Type::Forbrugsforeningen => &*FORBRUGSFORENINGEN_PATTERN_REGEX,
             Type::Dankort => &*DANKORT_PATTERN_REGEX,
             Type::Visa => &*VISA_PATTERN_REGEX,
+            Type::MIR => &*MIR_PATTERN_REGEX,
             Type::MasterCard => &*MASTERCARD_PATTERN_REGEX,
             Type::Amex => &*AMEX_PATTERN_REGEX,
             Type::DinersClub => &*DINERSCLUB_PATTERN_REGEX,
@@ -105,6 +109,7 @@ impl Type {
             Type::Forbrugsforeningen => Range { start: 16, end: 16 },
             Type::Dankort => Range { start: 16, end: 16 },
             Type::Visa => Range { start: 13, end: 16 },
+            Type::MIR => Range { start: 16, end: 19 },
             Type::MasterCard => Range { start: 16, end: 16 },
             Type::Amex => Range { start: 15, end: 15 },
             Type::DinersClub => Range { start: 14, end: 14 },
@@ -124,6 +129,7 @@ impl Type {
             Type::Forbrugsforeningen,
             Type::Dankort,
             Type::Visa,
+            Type::MIR,
             Type::MasterCard,
             Type::Amex,
             Type::DinersClub,

--- a/tests/validate.rs
+++ b/tests/validate.rs
@@ -62,6 +62,10 @@ fn jcb_numbers_valid() -> Vec<&'static str> {
     vec!["3530111333300000", "3566002020360505"]
 }
 
+fn mir_numbers_valid() -> Vec<&'static str> {
+    vec!["2200150220654583"]
+}
+
 fn unionpay_numbers_valid() -> Vec<&'static str> {
     vec![
         "6271136264806203568",
@@ -238,6 +242,14 @@ fn correct_jcb_card_name() {
     for number in jcb_numbers_valid() {
         let result = Validate::from(number).unwrap();
         assert_eq!(result.card_type.name(), "jcb".to_string());
+    }
+}
+
+#[test]
+fn correct_mir_card_name() {
+    for number in mir_numbers_valid() {
+        let result = Validate::from(number).unwrap();
+        assert_eq!(result.card_type.name(), "mir".to_string());
     }
 }
 


### PR DESCRIPTION
Dear valeriansaliou,

This PR was maded in consequence of wrong validation of MIR payment systems cards.
Cards issued by MIR could be more than 16 (19) symbols in length.

Here is links:
- [About MIR payment system](https://en.wikipedia.org/wiki/Mir_(payment_system))
- [BIN series list issued by NSPK MIR](https://bintable.com/scheme/NSPK-MIR?page=1)
- [MIR Payment Card System Regulations](https://nspk.com/upload/docs/eng/new/MIR%20Payment%20Card%20System%20Regulations_v.2.0.pdf)

Best regards,
Ad1n