### PR TITLE
Improve ease of use, and performance.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,10 +113,10 @@ impl Type {
         }
     }
 
-    fn all() -> Vec<Type> {
-        // Debit cards must come first, since they have more specific patterns than their\
-        //   credit-card equivalents.
-        vec![
+    const fn all() -> &'static [Type] {
+        // Debit cards must come first, since they have more specific patterns than their
+        // credit-card equivalents.
+        &[
             Type::VisaElectron,
             Type::Maestro,
             Type::Forbrugsforeningen,
@@ -179,7 +179,7 @@ impl Validate {
             for card in Type::all() {
                 // Validate brand-specific card number structure
                 if card.pattern().is_match(card_number) {
-                    return Ok(card);
+                    return Ok(*card);
                 }
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,7 @@ impl Validate {
         range.contains(&size)
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn is_luhn_valid(card_number: &str) -> bool {
         luhn::valid(card_number)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ lazy_static! {
 }
 
 /// Card type. Maps recognized cards, and validates their pattern and length.
-#[derive(PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[non_exhaustive]
 pub enum Type {
     // Debit
@@ -51,7 +51,7 @@ pub enum Type {
 }
 
 /// Validate error. Maps possible validation errors (eg. card number format invalid).
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[non_exhaustive]
 pub enum ValidateError {
     InvalidFormat,
@@ -134,7 +134,7 @@ impl Type {
 }
 
 /// Card validation utility. Used to validate a provided card number (length and Luhn checksum).
-#[derive(PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Validate {
     pub card_type: Type,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ lazy_static! {
 
 /// Card type. Maps recognized cards, and validates their pattern and length.
 #[derive(PartialEq)]
+#[non_exhaustive]
 pub enum Type {
     // Debit
     VisaElectron,
@@ -47,21 +48,16 @@ pub enum Type {
     Discover,
     UnionPay,
     JCB,
-
-    #[doc(hidden)]
-    __NonExhaustive,
 }
 
 /// Validate error. Maps possible validation errors (eg. card number format invalid).
 #[derive(Debug, PartialEq)]
+#[non_exhaustive]
 pub enum ValidateError {
     InvalidFormat,
     InvalidLength,
     InvalidLuhn,
     UnknownType,
-
-    #[doc(hidden)]
-    __NonExhaustive,
 }
 
 impl Type {
@@ -79,30 +75,28 @@ impl Type {
             Type::Discover => "discover",
             Type::UnionPay => "unionpay",
             Type::JCB => "jcb",
-            _ => "other",
         }
         .to_string()
     }
 
     fn pattern<'a>(&self) -> &'a Regex {
         match *self {
-            Type::VisaElectron => &*VISAELECTRON_PATTERN_REGEX,
-            Type::Maestro => &*MAESTRO_PATTERN_REGEX,
-            Type::Forbrugsforeningen => &*FORBRUGSFORENINGEN_PATTERN_REGEX,
-            Type::Dankort => &*DANKORT_PATTERN_REGEX,
-            Type::Visa => &*VISA_PATTERN_REGEX,
-            Type::MIR => &*MIR_PATTERN_REGEX,
-            Type::MasterCard => &*MASTERCARD_PATTERN_REGEX,
-            Type::Amex => &*AMEX_PATTERN_REGEX,
-            Type::DinersClub => &*DINERSCLUB_PATTERN_REGEX,
-            Type::Discover => &*DISCOVER_PATTERN_REGEX,
-            Type::UnionPay => &*UNIONPAY_PATTERN_REGEX,
-            Type::JCB => &*JCB_PATTERN_REGEX,
-            _ => &*OTHER_PATTERN_REGEX,
+            Type::VisaElectron => &VISAELECTRON_PATTERN_REGEX,
+            Type::Maestro => &MAESTRO_PATTERN_REGEX,
+            Type::Forbrugsforeningen => &FORBRUGSFORENINGEN_PATTERN_REGEX,
+            Type::Dankort => &DANKORT_PATTERN_REGEX,
+            Type::Visa => &VISA_PATTERN_REGEX,
+            Type::MIR => &MIR_PATTERN_REGEX,
+            Type::MasterCard => &MASTERCARD_PATTERN_REGEX,
+            Type::Amex => &AMEX_PATTERN_REGEX,
+            Type::DinersClub => &DINERSCLUB_PATTERN_REGEX,
+            Type::Discover => &DISCOVER_PATTERN_REGEX,
+            Type::UnionPay => &UNIONPAY_PATTERN_REGEX,
+            Type::JCB => &JCB_PATTERN_REGEX,
         }
     }
 
-    fn length<'a>(&self) -> Range<usize> {
+    fn length(&self) -> Range<usize> {
         match *self {
             Type::VisaElectron => Range { start: 16, end: 16 },
             Type::Maestro => Range { start: 12, end: 19 },
@@ -116,7 +110,6 @@ impl Type {
             Type::Discover => Range { start: 16, end: 16 },
             Type::JCB => Range { start: 16, end: 16 },
             Type::UnionPay => Range { start: 16, end: 19 },
-            _ => Range { start: 12, end: 19 },
         }
     }
 
@@ -148,26 +141,24 @@ pub struct Validate {
 
 impl Validate {
     pub fn from(card_number: &str) -> Result<Validate, ValidateError> {
-        let card_type = Validate::evaluate_type(&card_number)?;
+        let card_type = Validate::evaluate_type(card_number)?;
 
-        if Validate::is_length_valid(&card_number, &card_type) == false {
+        if !Validate::is_length_valid(card_number, &card_type) {
             return Err(ValidateError::InvalidLength);
         }
-        if Validate::is_luhn_valid(&card_number) == false {
+        if !Validate::is_luhn_valid(card_number) {
             return Err(ValidateError::InvalidLuhn);
         }
 
-        Ok(Validate {
-            card_type: card_type,
-        })
+        Ok(Validate { card_type })
     }
 
     pub fn evaluate_type(card_number: &str) -> Result<Type, ValidateError> {
         // Validate overall card number structure
-        if OTHER_PATTERN_REGEX.is_match(&card_number) {
+        if OTHER_PATTERN_REGEX.is_match(card_number) {
             for card in Type::all() {
                 // Validate brand-specific card number structure
-                if card.pattern().is_match(&card_number) {
+                if card.pattern().is_match(card_number) {
                     return Ok(card);
                 }
             }
@@ -189,6 +180,6 @@ impl Validate {
 
     #[inline]
     pub fn is_luhn_valid(card_number: &str) -> bool {
-        luhn::valid(&card_number)
+        luhn::valid(card_number)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ extern crate lazy_static;
 extern crate regex;
 
 use regex::Regex;
-use std::ops::Range;
+use std::ops::RangeInclusive;
 
 mod luhn;
 
@@ -62,7 +62,7 @@ pub enum ValidateError {
 
 impl Type {
     pub fn name(&self) -> String {
-        match *self {
+        match self {
             Type::VisaElectron => "visaelectron",
             Type::Maestro => "maestro",
             Type::Forbrugsforeningen => "forbrugsforeningen",
@@ -79,8 +79,8 @@ impl Type {
         .to_string()
     }
 
-    fn pattern<'a>(&self) -> &'a Regex {
-        match *self {
+    fn pattern(&self) -> &Regex {
+        match self {
             Type::VisaElectron => &VISAELECTRON_PATTERN_REGEX,
             Type::Maestro => &MAESTRO_PATTERN_REGEX,
             Type::Forbrugsforeningen => &FORBRUGSFORENINGEN_PATTERN_REGEX,
@@ -96,20 +96,20 @@ impl Type {
         }
     }
 
-    fn length(&self) -> Range<usize> {
-        match *self {
-            Type::VisaElectron => Range { start: 16, end: 16 },
-            Type::Maestro => Range { start: 12, end: 19 },
-            Type::Forbrugsforeningen => Range { start: 16, end: 16 },
-            Type::Dankort => Range { start: 16, end: 16 },
-            Type::Visa => Range { start: 13, end: 16 },
-            Type::MIR => Range { start: 16, end: 19 },
-            Type::MasterCard => Range { start: 16, end: 16 },
-            Type::Amex => Range { start: 15, end: 15 },
-            Type::DinersClub => Range { start: 14, end: 14 },
-            Type::Discover => Range { start: 16, end: 16 },
-            Type::JCB => Range { start: 16, end: 16 },
-            Type::UnionPay => Range { start: 16, end: 19 },
+    fn length(&self) -> RangeInclusive<usize> {
+        match self {
+            Type::VisaElectron => 16..=16,
+            Type::Maestro => 12..=19,
+            Type::Forbrugsforeningen => 16..=16,
+            Type::Dankort => 16..=16,
+            Type::Visa => 13..=16,
+            Type::MIR => 16..=19,
+            Type::MasterCard => 16..=16,
+            Type::Amex => 15..=15,
+            Type::DinersClub => 14..=14,
+            Type::Discover => 16..=16,
+            Type::JCB => 16..=16,
+            Type::UnionPay => 16..=19,
         }
     }
 
@@ -170,12 +170,10 @@ impl Validate {
     }
 
     pub fn is_length_valid(card_number: &str, card_type: &Type) -> bool {
-        // Notice: we don't use `contains()` yet as it's only available on nightly (as of v1.22)
-        // Also, `RangeInclusive` should have been used; we emulate its behavior with `Range`
         let size = card_number.len();
         let range = card_type.length();
 
-        size >= range.start && size <= range.end
+        range.contains(&size)
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,26 @@ impl Type {
     }
 }
 
+impl ToString for Type {
+    fn to_string(&self) -> String {
+        match self {
+            Type::VisaElectron => "VisaElectron",
+            Type::Maestro => "Maestro",
+            Type::Forbrugsforeningen => "Forbrugsforeningen",
+            Type::Dankort => "Dankort",
+            Type::Visa => "Visa",
+            Type::MIR => "MIR",
+            Type::MasterCard => "MasterCard",
+            Type::Amex => "Amex",
+            Type::DinersClub => "DinersClub",
+            Type::Discover => "Discover",
+            Type::UnionPay => "UnionPay",
+            Type::JCB => "JCB",
+        }
+        .to_string()
+    }
+}
+
 /// Card validation utility. Used to validate a provided card number (length and Luhn checksum).
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Validate {

--- a/src/luhn.rs
+++ b/src/luhn.rs
@@ -7,19 +7,20 @@
 pub fn valid(number: &str) -> bool {
     let mut checksum = 0;
 
-    let mut iter = number.chars().rev();
-    loop {
-        match iter.next() {
-            Some(c) => checksum += checksum_modifier_odd(c),
-            None => break,
-        }
-        match iter.next() {
-            Some(c) => checksum += checksum_modifier_even(c),
-            None => break,
+    let r_chars = number.chars().rev();
+    let range = 1..=number.chars().count();
+    let iter = range.zip(r_chars);
+
+    for (i, c) in iter {
+        let is_odd = i % 2 == 1;
+        if is_odd {
+            checksum += checksum_modifier_odd(c);
+        } else {
+            checksum += checksum_modifier_even(c);
         }
     }
 
-    return checksum % 10 == 0;
+    checksum % 10 == 0
 }
 
 fn checksum_modifier_odd(c: char) -> u32 {
@@ -30,9 +31,9 @@ fn checksum_modifier_even(c: char) -> u32 {
     let n = numeric_char_to_u32(c);
     let d = n * 2;
     if d <= 9 {
-        return d;
+        d
     } else {
-        return d - 9;
+        d - 9
     }
 }
 

--- a/src/luhn.rs
+++ b/src/luhn.rs
@@ -23,10 +23,12 @@ pub fn valid(number: &str) -> bool {
     checksum % 10 == 0
 }
 
+#[inline(always)]
 fn checksum_modifier_odd(c: char) -> u32 {
     numeric_char_to_u32(c)
 }
 
+#[inline(always)]
 fn checksum_modifier_even(c: char) -> u32 {
     let n = numeric_char_to_u32(c);
     let d = n * 2;
@@ -37,6 +39,7 @@ fn checksum_modifier_even(c: char) -> u32 {
     }
 }
 
+#[inline(always)]
 fn numeric_char_to_u32(c: char) -> u32 {
     (c as u32) - ('0' as u32)
 }

--- a/src/luhn.rs
+++ b/src/luhn.rs
@@ -5,20 +5,20 @@
 // In an effort to reduce the amount of dependencies in the `card-validate` library.
 
 pub fn valid(number: &str) -> bool {
-    let mut checksum = 0;
-
     let r_chars = number.chars().rev();
     let range = 1..=number.chars().count();
     let iter = range.zip(r_chars);
 
-    for (i, c) in iter {
+    let checksum = iter.fold(0, |mut checksum, (i, c)| {
         let is_odd = i % 2 == 1;
         if is_odd {
             checksum += checksum_modifier_odd(c);
         } else {
             checksum += checksum_modifier_even(c);
-        }
-    }
+        };
+
+        checksum
+    });
 
     checksum % 10 == 0
 }


### PR DESCRIPTION
I needed to pass around the card type to a generic function, where the function required Debug, and a few other traits implemented. After taking a look at the source code I thought a cleanup was in order.

Short list of what is done.
- I got rid of all of the clippy warnings.
- Derived, and/or implemented various traits that are often used, and that have zero cost to implement.
- Inlined smaller functions for performance reasons. 

Performance is slightly faster and much more consistent due to (I assume) cache hits.

- [x]  Ran `cargo check`
- [x]  Ran `cargo clippy`
- [x]  All tests ran successfully.

Edit: There isn't any change in public methods, so this should only modernize/optimize etc. internal methods.